### PR TITLE
Restore static export for serverless CDN builds, split client layout, and sync dynamic routes

### DIFF
--- a/web/src/app/ClientRootLayout.tsx
+++ b/web/src/app/ClientRootLayout.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { NextIntlClientProvider } from 'next-intl';
+import { useEffect, useState } from 'react';
+import { DEFAULT_LOCALE, type Locale } from '@/i18n/request';
+import { Root } from '@/components/Root';
+import { QueryProvider } from '@/providers/QueryProvider';
+import { AuthProvider } from '@/contexts/AuthContext';
+import { RuntimeConfigProvider } from '@/components/RuntimeConfigProvider';
+import { ToastContainer } from '@/shared/components/toast-container';
+import { AppModeProvider } from '@/contexts/AppModeContext';
+import StyledJsxRegistry from '@/registry';
+import { getEnabledProviders, getAuthEnv } from '@/lib/utils/oauth-providers';
+import { ClientRouter } from '@/components/ClientRouter';
+
+import enMessages from '../../messages/en.json';
+import ruMessages from '../../messages/ru.json';
+
+interface ClientRootLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function ClientRootLayout({ children }: ClientRootLayoutProps) {
+  const [locale, setLocale] = useState<Locale>(DEFAULT_LOCALE);
+  const [messages, setMessages] = useState(enMessages);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const detectLocale = (): Locale => {
+      const cookieLocale = document.cookie
+        .split('; ')
+        .find(row => row.startsWith('NEXT_LOCALE='))
+        ?.split('=')[1];
+
+      if (cookieLocale === 'ru' || cookieLocale === 'en') {
+        return cookieLocale;
+      }
+
+      const stored = localStorage.getItem('language');
+      if (stored === 'ru' || stored === 'en') {
+        return stored;
+      }
+
+      const browserLang = navigator.language?.split('-')[0]?.toLowerCase() || 'en';
+      return browserLang === 'ru' ? 'ru' : 'en';
+    };
+
+    const detectedLocale = detectLocale();
+    setLocale(detectedLocale);
+    setMessages(detectedLocale === 'ru' ? ruMessages : enMessages);
+
+    document.documentElement.lang = detectedLocale;
+
+    if (!document.cookie.includes('NEXT_LOCALE=')) {
+      const browserLang = navigator.language?.split('-')[0]?.toLowerCase() || 'en';
+      const defaultLocale = browserLang === 'ru' ? 'ru' : 'en';
+      document.cookie = `NEXT_LOCALE=${defaultLocale}; max-age=${365 * 24 * 60 * 60}; path=/; samesite=lax`;
+    }
+
+    setMounted(true);
+  }, []);
+
+  const env = getAuthEnv();
+  const enabledProviders = getEnabledProviders(env);
+  const authnEnabled = (process.env.NEXT_PUBLIC_AUTHN_ENABLED || process.env.AUTHN_ENABLED) === 'true';
+
+  if (!mounted) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <StyledJsxRegistry>
+      <AppModeProvider>
+        <QueryProvider>
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <ClientRouter />
+            <AuthProvider>
+              <RuntimeConfigProvider
+                fallbackEnabledProviders={enabledProviders}
+                fallbackAuthnEnabled={authnEnabled}
+              >
+                <Root>{children}</Root>
+              </RuntimeConfigProvider>
+              <ToastContainer />
+            </AuthProvider>
+          </NextIntlClientProvider>
+        </QueryProvider>
+      </AppModeProvider>
+    </StyledJsxRegistry>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,23 +1,7 @@
-'use client';
-
 import type { Viewport } from 'next';
 import './globals.css';
-import { NextIntlClientProvider } from 'next-intl';
-import { useEffect, useState } from 'react';
-import { detectBrowserLanguage, SUPPORTED_LOCALES, DEFAULT_LOCALE, type Locale } from '@/i18n/request';
-import { Root } from '@/components/Root';
-import { QueryProvider } from '@/providers/QueryProvider';
-import { AuthProvider } from '@/contexts/AuthContext';
-import { RuntimeConfigProvider } from '@/components/RuntimeConfigProvider';
-import { ToastContainer } from '@/shared/components/toast-container';
-import { AppModeProvider } from '@/contexts/AppModeContext';
-import StyledJsxRegistry from '@/registry';
-import { getEnabledProviders, getAuthEnv } from '@/lib/utils/oauth-providers';
-import { ClientRouter } from '@/components/ClientRouter';
-
-// Import translation messages
-import enMessages from '../../messages/en.json';
-import ruMessages from '../../messages/ru.json';
+import { DEFAULT_LOCALE } from '@/i18n/request';
+import ClientRootLayout from './ClientRootLayout';
 
 export const viewport: Viewport = {
     width: 'device-width',
@@ -31,103 +15,8 @@ export default function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    const [locale, setLocale] = useState<Locale>(DEFAULT_LOCALE);
-    const [messages, setMessages] = useState(enMessages);
-    const [mounted, setMounted] = useState(false);
-
-    useEffect(() => {
-        // Client-side locale detection
-        const detectLocale = (): Locale => {
-            // 1. Check cookie first
-            const cookieLocale = document.cookie
-                .split('; ')
-                .find(row => row.startsWith('NEXT_LOCALE='))
-                ?.split('=')[1];
-
-            if (cookieLocale === 'ru' || cookieLocale === 'en') {
-                return cookieLocale;
-            }
-
-            // 2. Check localStorage (for 'auto' preference)
-            const stored = localStorage.getItem('language');
-            if (stored === 'ru' || stored === 'en') {
-                return stored;
-            }
-
-            // 3. Detect from browser
-            const browserLang = navigator.language?.split('-')[0]?.toLowerCase() || 'en';
-            return browserLang === 'ru' ? 'ru' : 'en';
-        };
-
-        const detectedLocale = detectLocale();
-        setLocale(detectedLocale);
-        setMessages(detectedLocale === 'ru' ? ruMessages : enMessages);
-        
-        // Set HTML lang attribute
-        document.documentElement.lang = detectedLocale;
-        
-        // Set cookie if not present
-        if (!document.cookie.includes('NEXT_LOCALE=')) {
-            const browserLang = navigator.language?.split('-')[0]?.toLowerCase() || 'en';
-            const defaultLocale = browserLang === 'ru' ? 'ru' : 'en';
-            document.cookie = `NEXT_LOCALE=${defaultLocale}; max-age=${365 * 24 * 60 * 60}; path=/; samesite=lax`;
-        }
-        
-        setMounted(true);
-    }, []);
-
-    // Use build-time defaults as fallback (RuntimeConfigProvider will override with runtime config)
-    const env = getAuthEnv();
-    const enabledProviders = getEnabledProviders(env);
-    const authnEnabled = (process.env.NEXT_PUBLIC_AUTHN_ENABLED || process.env.AUTHN_ENABLED) === 'true';
-
-    // Prevent hydration mismatch - render with default locale first
-    if (!mounted) {
-        return (
-            <html lang={DEFAULT_LOCALE} suppressHydrationWarning>
-                <head>
-                    <script
-                        dangerouslySetInnerHTML={{
-                            __html: `
-(function() {
-  try {
-    const stored = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    let theme = 'light';
-    
-    if (stored === 'dark' || stored === 'light') {
-      theme = stored;
-    } else if (stored === 'auto' || !stored) {
-      theme = prefersDark ? 'dark' : 'light';
-    }
-    
-    document.documentElement.setAttribute('data-theme', theme);
-  } catch (e) {
-    // localStorage not available, use default
-    document.documentElement.setAttribute('data-theme', 'light');
-  }
-})();
-                        `,
-                        }}
-                    />
-                    <link
-                        href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap"
-                        rel="stylesheet"
-                    />
-                    <link
-                        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
-                        rel="stylesheet"
-                    />
-                </head>
-                <body suppressHydrationWarning>
-                    <div>Loading...</div>
-                </body>
-            </html>
-        );
-    }
-
     return (
-        <html lang={locale} suppressHydrationWarning>
+        <html lang={DEFAULT_LOCALE} suppressHydrationWarning>
             <head>
                 <script
                     dangerouslySetInnerHTML={{
@@ -163,25 +52,7 @@ export default function RootLayout({
                 />
             </head>
             <body suppressHydrationWarning>
-                <StyledJsxRegistry>
-                    <AppModeProvider>
-                        <QueryProvider>
-                            <NextIntlClientProvider locale={locale} messages={messages}>
-                                <ClientRouter />
-                                <AuthProvider>
-                                    {/* RuntimeConfigProvider fetches config from API and passes to AuthWrapper */}
-                                    <RuntimeConfigProvider 
-                                        fallbackEnabledProviders={enabledProviders}
-                                        fallbackAuthnEnabled={authnEnabled}
-                                    >
-                                        <Root>{children}</Root>
-                                    </RuntimeConfigProvider>
-                                    <ToastContainer />
-                                </AuthProvider>
-                            </NextIntlClientProvider>
-                        </QueryProvider>
-                    </AppModeProvider>
-                </StyledJsxRegistry>
+                <ClientRootLayout>{children}</ClientRootLayout>
             </body>
         </html>
     );

--- a/web/src/app/meriter/communities/[id]/create-poll/page.tsx
+++ b/web/src/app/meriter/communities/[id]/create-poll/page.tsx
@@ -1,7 +1,7 @@
 import { CreatePollPageClient } from './CreatePollPageClient';
 
 interface CreatePollPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,8 +10,8 @@ export async function generateStaticParams(): Promise<Array<{ id: string }>> {
   return [];
 }
 
-export default async function CreatePollPage({ params }: CreatePollPageProps) {
-  const { id } = await params;
+export default function CreatePollPage({ params }: CreatePollPageProps) {
+  const { id } = params;
   return <CreatePollPageClient communityId={id} />;
 }
 

--- a/web/src/app/meriter/communities/[id]/create/page.tsx
+++ b/web/src/app/meriter/communities/[id]/create/page.tsx
@@ -1,7 +1,7 @@
 import { CreatePublicationPageClient } from './CreatePublicationPageClient';
 
 interface CreatePublicationPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,8 +10,8 @@ export async function generateStaticParams(): Promise<Array<{ id: string }>> {
   return [];
 }
 
-export default async function CreatePublicationPage({ params }: CreatePublicationPageProps) {
-  const { id } = await params;
+export default function CreatePublicationPage({ params }: CreatePublicationPageProps) {
+  const { id } = params;
   return <CreatePublicationPageClient communityId={id} />;
 }
 

--- a/web/src/app/meriter/communities/[id]/edit-poll/[pollId]/page.tsx
+++ b/web/src/app/meriter/communities/[id]/edit-poll/[pollId]/page.tsx
@@ -1,7 +1,7 @@
 import { EditPollPageClient } from './EditPollPageClient';
 
 interface EditPollPageProps {
-  params: Promise<{ id: string; pollId: string }>;
+  params: { id: string; pollId: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams(): Promise<Array<{ id: string; pollId
   return [];
 }
 
-export default async function EditPollPage({ params }: EditPollPageProps) {
-  const { id, pollId } = await params;
+export default function EditPollPage({ params }: EditPollPageProps) {
+  const { id, pollId } = params;
   return <EditPollPageClient communityId={id} pollId={pollId} />;
 }

--- a/web/src/app/meriter/communities/[id]/edit/[publicationId]/page.tsx
+++ b/web/src/app/meriter/communities/[id]/edit/[publicationId]/page.tsx
@@ -1,7 +1,7 @@
 import { EditPublicationPageClient } from './EditPublicationPageClient';
 
 interface EditPublicationPageProps {
-  params: Promise<{ id: string; publicationId: string }>;
+  params: { id: string; publicationId: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams(): Promise<Array<{ id: string; public
   return [];
 }
 
-export default async function EditPublicationPage({ params }: EditPublicationPageProps) {
-  const { id, publicationId } = await params;
+export default function EditPublicationPage({ params }: EditPublicationPageProps) {
+  const { id, publicationId } = params;
   return <EditPublicationPageClient communityId={id} publicationId={publicationId} />;
 }

--- a/web/src/app/meriter/communities/[id]/members/page.tsx
+++ b/web/src/app/meriter/communities/[id]/members/page.tsx
@@ -1,7 +1,7 @@
 import { CommunityMembersPageClient } from './CommunityMembersPageClient';
 
 interface CommunityMembersPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams(): Promise<Array<{ id: string }>> {
   return [];
 }
 
-export default async function CommunityMembersPage({ params }: CommunityMembersPageProps) {
-  const { id } = await params;
+export default function CommunityMembersPage({ params }: CommunityMembersPageProps) {
+  const { id } = params;
   return <CommunityMembersPageClient communityId={id} />;
 }

--- a/web/src/app/meriter/communities/[id]/page.tsx
+++ b/web/src/app/meriter/communities/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { CommunityPageClient } from './CommunityPageClient';
 
 interface CommunityPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams(): Promise<Array<{ id: string }>> {
   return [];
 }
 
-export default async function CommunityPage({ params }: CommunityPageProps) {
-  const { id } = await params;
+export default function CommunityPage({ params }: CommunityPageProps) {
+  const { id } = params;
   return <CommunityPageClient communityId={id} />;
 }

--- a/web/src/app/meriter/communities/[id]/posts/[slug]/page.tsx
+++ b/web/src/app/meriter/communities/[id]/posts/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { PostPageClient } from './PostPageClient';
 
 interface PostPageProps {
-  params: Promise<{ id: string; slug: string }>;
+  params: { id: string; slug: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams(): Promise<Array<{ id: string; slug: 
   return [];
 }
 
-export default async function PostPage({ params }: PostPageProps) {
-  const { id, slug } = await params;
+export default function PostPage({ params }: PostPageProps) {
+  const { id, slug } = params;
   return <PostPageClient communityId={id} slug={slug} />;
 }

--- a/web/src/app/meriter/communities/[id]/rules/page.tsx
+++ b/web/src/app/meriter/communities/[id]/rules/page.tsx
@@ -1,7 +1,7 @@
 import { CommunityRulesPageClient } from './CommunityRulesPageClient';
 
 interface CommunityRulesPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams(): Promise<Array<{ id: string }>> {
   return [];
 }
 
-export default async function CommunityRulesPage({ params }: CommunityRulesPageProps) {
-  const { id } = await params;
+export default function CommunityRulesPage({ params }: CommunityRulesPageProps) {
+  const { id } = params;
   return <CommunityRulesPageClient communityId={id} />;
 }

--- a/web/src/app/meriter/communities/[id]/settings/page.tsx
+++ b/web/src/app/meriter/communities/[id]/settings/page.tsx
@@ -1,7 +1,7 @@
 import { CommunitySettingsPageClient } from './CommunitySettingsPageClient';
 
 interface CommunitySettingsPageProps {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams(): Promise<Array<{ id: string }>> {
   return [];
 }
 
-export default async function CommunitySettingsPage({ params }: CommunitySettingsPageProps) {
-  const { id } = await params;
+export default function CommunitySettingsPage({ params }: CommunitySettingsPageProps) {
+  const { id } = params;
   return <CommunitySettingsPageClient communityId={id} />;
 }

--- a/web/src/app/meriter/users/[userId]/page.tsx
+++ b/web/src/app/meriter/users/[userId]/page.tsx
@@ -1,7 +1,7 @@
 import { UserProfilePageClient } from './UserProfilePageClient';
 
 interface UserProfilePageProps {
-  params: Promise<{ userId: string }>;
+  params: { userId: string };
 }
 
 // Required for static export with dynamic routes
@@ -10,7 +10,7 @@ export async function generateStaticParams() {
   return [];
 }
 
-export default async function UserProfilePage({ params }: UserProfilePageProps) {
-  const { userId } = await params;
+export default function UserProfilePage({ params }: UserProfilePageProps) {
+  const { userId } = params;
   return <UserProfilePageClient userId={userId} />;
 }

--- a/web/src/config/index.ts
+++ b/web/src/config/index.ts
@@ -12,6 +12,8 @@
 
 import { z } from 'zod';
 
+const isBuildTime = process.env.NEXT_PHASE === 'phase-production-build' || process.env.NEXT_PHASE === 'phase-export';
+
 /**
  * Derive application URL from DOMAIN
  * Protocol: http:// for localhost, https:// for production
@@ -40,6 +42,9 @@ function deriveAppUrl(): string {
     // Backward compatibility: if APP_URL exists but DOMAIN doesn't, use APP_URL
     if (process.env.APP_URL) {
       return process.env.APP_URL;
+    }
+    if (isBuildTime) {
+      return 'http://localhost';
     }
     throw new Error('DOMAIN environment variable is required on server-side. Set DOMAIN to your domain (e.g., dev.meriter.pro, stage.meriter.pro, or meriter.pro).');
   }
@@ -131,6 +136,9 @@ function getDomainConfig(): string {
   // Server-side: require DOMAIN env var (already validated by deriveAppUrl, but double-check)
   const domain = process.env.NEXT_PUBLIC_DOMAIN || process.env.DOMAIN;
   if (!domain) {
+    if (isBuildTime) {
+      return 'localhost';
+    }
     throw new Error(
       'DOMAIN environment variable is required on server-side. ' +
       'Set DOMAIN to your domain (e.g., dev.meriter.pro, stage.meriter.pro, or meriter.pro). ' +


### PR DESCRIPTION
### Motivation
- Produce a fully static, serverless build (deployable to a CDN) so the Next.js server is only used in development. 
- Dynamic app routes previously broke static export detection and prerendering, so they must be treated as client-handled routes. 
- Client-only providers in the root layout cause hydration/prerender instability and must be moved to a client component. 
- Ensure build-time config access does not throw during a production build when `DOMAIN` is not set.

### Description
- Re-enabled static export by restoring `output: 'export'` in `web/next.config.js` so `next build` produces static HTML/CSS/JS output. 
- Converted dynamic app route pages to synchronous props and added `generateStaticParams()` that returns `[]` for each dynamic route (files under `web/src/app/meriter/...`) so dynamic routes are handled client-side. 
- Split the root layout into a server wrapper (`web/src/app/layout.tsx`) that sets defaults and a client-only `web/src/app/ClientRootLayout.tsx` that contains `NextIntlClientProvider`, providers, and client initialization logic. 
- Added a build-time detection flag (`isBuildTime`) and safe fallbacks in `web/src/config/index.ts` to return `http://localhost`/`localhost` during the production build to avoid prerender-time exceptions.

### Testing
- Searched for server-side `params: Promise` occurrences with `rg -n "params: Promise" web/src/app -S` and updated impacted pages, which were staged and committed. 
- Attempted `pnpm install` and the workspace install failed due to a private registry / authorization error (`ERR_PNPM_FETCH_403` when fetching `@trpc/server`). 
- Attempted `pnpm -C web build`; the build could not complete locally because workspace dependencies were missing and resulted in webpack `Module not found` errors. 
- No unit tests were added or changed; the changes were validated via automated edits and build attempts but the final production build could not be executed in this environment due to dependency/registry issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b2e4e502483339a17f43538f7409f)