### PR TITLE
Fix Jest resolution for community invite metadata tests.

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -50,6 +50,7 @@ module.exports = {
       "^@/hooks/(.*)$": "<rootDir>/src/hooks/$1",
       "^@/types/(.*)$": "<rootDir>/src/types/$1",
       "^@/lib/(.*)$": "<rootDir>/src/lib/$1",
+      "^@/i18n/(.*)$": "<rootDir>/src/i18n/$1",
       "^@/shared/(.*)$": "<rootDir>/src/shared/$1",
       "^@/config/(.*)$": "<rootDir>/src/config/$1",
       "^@/config$": "<rootDir>/src/config/index.ts",

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -220,25 +220,30 @@ jest.mock('@/shared/lib/deep-link-handler', () => ({
 }));
 
 // Mock config
-jest.mock('@/config', () => ({
-  config: {
-    app: {
-      isDevelopment: true,
-      url: 'http://localhost:3000',
-    },
-    api: {
-      url: 'http://localhost:3000',
-    },
-    telegram: {
-      botUsername: 'test_bot',
-      botToken: 'test_token',
-      botUrl: 'https://t.me/test_bot',
-    },
-    development: {
-      fakeDataMode: false,
-      testAuthMode: false,
-    },
+const mockConfig = {
+  app: {
+    isDevelopment: true,
+    url: 'http://localhost:3000',
   },
+  api: {
+    baseUrl: 'http://localhost:8001',
+    url: 'http://localhost:3000',
+  },
+  telegram: {
+    botUsername: 'test_bot',
+    botToken: 'test_token',
+    botUrl: 'https://t.me/test_bot',
+  },
+  development: {
+    fakeDataMode: false,
+    testAuthMode: false,
+  },
+};
+
+jest.mock('@/config', () => ({
+  __esModule: true,
+  default: mockConfig,
+  config: mockConfig,
   isFakeDataMode: jest.fn(() => false),
   isTestAuthMode: jest.fn(() => false),
   isDevelopment: jest.fn(() => true),

--- a/web/src/lib/i18n/__tests__/community-invite-metadata.test.ts
+++ b/web/src/lib/i18n/__tests__/community-invite-metadata.test.ts
@@ -12,7 +12,7 @@ describe('community-invite-metadata', () => {
       canonicalPath: '/meriter/join/short-token',
     });
 
-    expect(metadata.title).toBeTruthy();
+    expect(metadata.title).toBe('Join community');
     global.fetch = originalFetch;
   });
 


### PR DESCRIPTION
Map @/i18n imports in web Jest config and align the config mock default export with server metadata helpers.