### PR TITLE
fix(ci): skip offline stage so prod deploy can run

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -196,7 +196,8 @@ jobs:
             {
               echo "build_type=release"
               echo "run_dev_deploy=false"
-              echo "run_stage_deploy=true"
+              # Stage VPS is offline; do not gate production on deploy-stage.
+              echo "run_stage_deploy=false"
               echo "run_prod_deploy=true"
             } >> "$GITHUB_OUTPUT"
           else
@@ -408,7 +409,6 @@ jobs:
       - test-unit
       - test-e2e
       - build-images
-      - deploy-stage
     if: needs.determine-target.outputs.run_prod_deploy == 'true'
     environment:
       name: prod


### PR DESCRIPTION
## Summary
- Stage VPS is offline (`ssh-keyscan` fails), which failed **Deploy to stage** on the release run after #46.
- `deploy-prod` depended on `deploy-stage`, so production never reached the manual approval gate.
- Disable stage deploy on `main` and remove the hard `needs: deploy-stage` edge so prod can proceed (still requires `prod` environment approval).

## Test plan
- [ ] Merge → watch Build and Deploy Images on `main`
- [ ] Approve `prod` environment when pending
- [ ] Confirm Deploy to production server succeeds