### PR TITLE
fix(ops): sync prod DOMAIN=dobro onto dev

### DIFF
--- a/docs/business-docs-ru/13-telegram-stack-deployment-ru.md
+++ b/docs/business-docs-ru/13-telegram-stack-deployment-ru.md
@@ -136,7 +136,7 @@ MERITER_PRODUCT_MODE=telegram_mvp
 TELEGRAM_BOT_ENABLED=true
 BOT_TOKEN=...
 BOT_USERNAME=meriter_bot
-DOMAIN=meriter.pro
+DOMAIN=dobro.meriter.pro
 JWT_SECRET=...
 MONGO_URL=...
 ```
@@ -158,7 +158,7 @@ TELEGRAM_BOT_ENABLED=false          # webhook не обрабатывается
 BOT_TOKEN=...                       # всё равно нужен для Login Widget
 BOT_USERNAME=meriter_bot
 COMMUNITY_WEB_BASE_URL=https://community-dobro.meriter.pro
-DOMAIN=meriter.pro
+DOMAIN=dobro.meriter.pro
 COMMUNITY_DOMAIN=community-dobro.meriter.pro
 JWT_SECRET=...
 MONGO_URL=...
@@ -207,7 +207,7 @@ docker compose run --rm bot-webhook-init
 
 ```env
 # === Общее ===
-DOMAIN=meriter.pro
+DOMAIN=dobro.meriter.pro
 COMMUNITY_DOMAIN=community-dobro.meriter.pro
 JWT_SECRET=<openssl rand -base64 32>
 MONGO_ADMIN_PASSWORD=<strong>

--- a/scripts/vps/profiles/prod.env
+++ b/scripts/vps/profiles/prod.env
@@ -1,7 +1,11 @@
-# Non-secret Telegram MVP settings for prod VPS (community-dobro.meriter.pro).
+# Non-secret Telegram MVP settings for prod VPS (37.139.41.111 / dobro.meriter.pro).
 # BOT_TOKEN: set on server or via GitHub prod environment secret BOT_TOKEN at deploy.
+#
+# DOMAIN must be the hostname that has a public A record and is used for the main web
+# app in Caddy. meriter.pro currently has no A record; the prod site is dobro.meriter.pro.
+# community-web stays on community-dobro.meriter.pro.
 
-DOMAIN=meriter.pro
+DOMAIN=dobro.meriter.pro
 COMMUNITY_DOMAIN=community-dobro.meriter.pro
 COMMUNITY_WEB_BASE_URL=https://community-dobro.meriter.pro
 
@@ -9,3 +13,4 @@ MERITER_PRODUCT_MODE=telegram_mvp
 TELEGRAM_BOT_ENABLED=true
 OAUTH_TELEGRAM_ENABLED=true
 BOT_USERNAME=meriter_bot
+OAUTH_TELEGRAM_BOT_USERNAME=meriter_bot


### PR DESCRIPTION
Backport #48 prod.env + runbook DOMAIN fixes to `dev` so the next merge to main cannot resurrect `DOMAIN=meriter.pro`.

Made with [Cursor](https://cursor.com)